### PR TITLE
Corrected path for "main"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "version": "1.0.1",
   "description": "Redirect component for react-router v6",
-  "main": "./dist/dist/index.js",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "scripts": {


### PR DESCRIPTION
`./dist/dist/index.js` was a non-existent path, which can result in errors.

Running tests within a Lerna monorepo resulted in a test failure:
```
Cannot find module 'react-router6-redirect' from 'components/App.tsx'
```

This PR corrects the path for "main".